### PR TITLE
Fix city name spelling and update performance metrics

### DIFF
--- a/src/pages/Performance.tsx
+++ b/src/pages/Performance.tsx
@@ -137,7 +137,7 @@ const Performance = () => {
     },
     { key: "fastestCity", label: "Fastest City", headerClassName: "w-40", cellClassName: "w-40" },
     { key: "slowestCity", label: "Slowest City", headerClassName: "w-40", cellClassName: "w-40" },
-    { key: "avgTimeTaken", label: "Avg. Time Taken", headerClassName: "w-44", cellClassName: "w-44" },
+    { key: "avgTimeTaken", label: "Avg. time taken", headerClassName: "w-44", cellClassName: "w-44" },
   ];
 
   return (


### PR DESCRIPTION
## Purpose
Update the performance tab to use correct city names and improve the display of issue resolution performance details. The user requested standardized city names for the performance metrics and better formatting for the average time taken column.

## Code changes
- **Fixed spelling**: Corrected "Ghaziadabad" to "Ghaziabad" across all performance table entries
- **Updated column label**: Changed "Avg. Time Taken" to "Avg. time taken" for consistency
- **Updated metric cards**: 
  - Changed fastest city from "Chennai" to "Noida" 
  - Changed slowest city from "Mumbai" to "Ghaziabad"
  - Updated subtitles to use actual city names instead of placeholder textTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a77a2add5da041deb209a284a7a22e6a/curry-home)

👀 [Preview Link](https://a77a2add5da041deb209a284a7a22e6a-curry-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a77a2add5da041deb209a284a7a22e6a</projectId>-->
<!--<branchName>curry-home</branchName>-->