### PR TITLE
Update issue status chart with double bars

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -74,11 +74,11 @@ const Home = () => {
         />
       </div>
 
-      {/* Issues Resolved Chart - Stacked with Line */}
+      {/* Issues Status - Double Bar: Actual Raised vs Actual Resolved */}
       <IssuesChart
         title="Issue Status"
         data={resolvedChartData}
-        type="stacked-line"
+        type="double"
       />
 
       <IssuesChart


### PR DESCRIPTION
Implement a new 'double' chart type for the Home screen's 'Issue Status' chart to display Actual Raised and Actual Resolved as separate bars, including conditional coloring for resolved issues and a percentage label.

---
<a href="https://cursor.com/background-agent?bcId=bc-ae28ee08-acfc-428f-9e1f-b7cc6356ff87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ae28ee08-acfc-428f-9e1f-b7cc6356ff87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

