### PR TITLE
Update issue card and status bar colors

### DIFF
--- a/src/components/IssueStatCard.tsx
+++ b/src/components/IssueStatCard.tsx
@@ -17,7 +17,7 @@ interface IssueStatCardProps {
 
 const bgByVariant: Record<Variant, string> = {
   raised: "bg-yellow-300 text-black",
-  resolved: "bg-red-400 text-white",
+  resolved: "bg-[#555555] text-white",
 };
 
 export function IssueStatCard({ title, target, actual, variant, className, leftLabelText, rightLabelText, subtitle }: IssueStatCardProps) {

--- a/src/components/IssuesChart.tsx
+++ b/src/components/IssuesChart.tsx
@@ -178,7 +178,7 @@ export const IssuesChart = <TEntry extends ChartDataPoint = ChartDataPoint>({ ti
               <YAxis stroke="hsl(var(--muted-foreground))" fontSize={12} fontWeight={500} domain={[0, 'dataMax + 10']} tickCount={6} />
               <Tooltip content={<CustomTooltip />} />
               <Legend wrapperStyle={{ fontSize: isMobile ? 12 : 14 }} verticalAlign="bottom" align="center" />
-              <Bar dataKey="actualRaised" name="Actual Raised" fill="#9CA3AF" radius={[6, 6, 0, 0]} barSize={isMobile ? 20 : 28} isAnimationActive={!isMobile}>
+              <Bar dataKey="actualRaised" name="Actual Raised" fill="#555555" radius={[6, 6, 0, 0]} barSize={isMobile ? 20 : 28} isAnimationActive={!isMobile}>
                 <LabelList dataKey="actualRaised" position="top" content={<BarValueLabel />} />
               </Bar>
               <Bar dataKey="actualResolved" name="Actual Resolved" radius={[6, 6, 0, 0]} barSize={isMobile ? 20 : 28} isAnimationActive={!isMobile}>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -44,6 +44,8 @@ const resolutionRates = [
   { name: "Noida", raised: 93 },
 ];
 
+const resolutionRatesSorted = [...resolutionRates].sort((a, b) => b.raised - a.raised);
+
 const Home = () => {
   return (
     <div className="space-y-6">
@@ -83,7 +85,7 @@ const Home = () => {
 
       <IssuesChart
         title="Actual Resolution Rate by City"
-        data={resolutionRates}
+        data={resolutionRatesSorted}
         showTarget={false}
         showLegend={true}
         valueSuffix="%"

--- a/src/pages/Performance.tsx
+++ b/src/pages/Performance.tsx
@@ -159,6 +159,8 @@ const Performance = ({ activeModule }: PerformanceProps) => {
       { city: "Noida", percent: 64 },
     ];
 
+    const cityPercentsSorted = [...cityPercents].sort((a, b) => b.percent - a.percent);
+
     const best = cityPercents.reduce((a, b) => (b.percent > a.percent ? b : a));
     const lagging = cityPercents.reduce((a, b) => (b.percent < a.percent ? b : a));
     const overall = 38; // Overall Avg
@@ -207,7 +209,7 @@ const Performance = ({ activeModule }: PerformanceProps) => {
 
         <IssuesChart
           title="Malba (collected/target)"
-          data={cityPercents.map(c => ({ name: c.city, raised: c.percent }))}
+          data={cityPercentsSorted.map(c => ({ name: c.city, raised: c.percent }))}
           type="bar"
           showTarget={false}
           valueSuffix="%"


### PR DESCRIPTION
Update grey bars and issue card background to `#555555` and sort city resolution charts from highest to lowest.

---
<a href="https://cursor.com/background-agent?bcId=bc-57710a6c-b778-478b-ab34-96421ed4c19b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-57710a6c-b778-478b-ab34-96421ed4c19b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

