### PR TITLE
Show percentages on issue status chart bars

### DIFF
--- a/src/components/IssuesChart.tsx
+++ b/src/components/IssuesChart.tsx
@@ -138,15 +138,16 @@ export const IssuesChart = <TEntry extends ChartDataPoint = ChartDataPoint>({ ti
       return getDspThresholdFill(pct);
     };
 
-    const PercentLabel = (props: { x?: number; y?: number; width?: number; value?: number; payload?: TEntry }) => {
-      const { x, y, width, payload } = props;
-      const resolved = Number((payload as any)?.actualResolved) || 0;
-      const raised = Number((payload as any)?.actualRaised) || 0;
+    const PercentLabel = (props: { x?: number; y?: number; width?: number; index?: number }) => {
+      const { x, y, width, index } = props;
+      const record = (index != null ? data[index] : undefined) as any;
+      const resolved = Number(record?.actualResolved) || 0;
+      const raised = Number(record?.actualRaised) || 0;
       if (!raised) return null;
       const pct = Math.round((resolved / raised) * 100);
       const posX = (x || 0) + (width || 0) / 2;
       const posY = (y || 0) + 14; // inside the bar, near the top
-      const fillColor = getResolvedFill(payload as TEntry);
+      const fillColor = getDspThresholdFill(pct);
       const textFill = fillColor === '#FFC107' ? '#111827' : '#ffffff';
       return (
         <text


### PR DESCRIPTION
Display percentages directly inside the Issue Status chart bars, not just on hover.

---
<a href="https://cursor.com/background-agent?bcId=bc-a5e22c96-c753-48f8-b7b3-258dd8574015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a5e22c96-c753-48f8-b7b3-258dd8574015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

