### PR TITLE
Revert unauthorized dsp chart and table changes

### DIFF
--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -107,18 +107,10 @@ export const DashboardHeader = ({
             {cities.map((city) => (
               <Button
                 key={city}
-                variant={activeModule === "DSP" ? "outline" : (selectedCity === city ? "default" : "outline")}
+                variant={selectedCity === city ? "default" : "outline"}
                 size="sm"
                 onClick={() => onCityChange(city)}
-                aria-pressed={selectedCity === city}
-                className={cn(
-                  "nav-button h-8 px-2 text-xs truncate",
-                  activeModule === "DSP"
-                    ? (selectedCity === city
-                        ? "bg-green-600 text-white hover:bg-green-700 border-green-600"
-                        : "")
-                    : ""
-                )}
+                className="nav-button h-8 px-2 text-xs truncate"
               >
                 {city}
               </Button>

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -12,27 +12,27 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 
-interface TableColumn<TRow extends Record<string, unknown>> {
+interface TableColumn {
   key: string;
   label: string;
-  render?: (value: unknown, row: TRow) => React.ReactNode;
+  render?: (value: any, row: any) => React.ReactNode;
   headerClassName?: string;
   cellClassName?: string;
 }
 
-interface DataTableProps<TRow extends Record<string, unknown>> {
+interface DataTableProps {
   title?: string;
-  columns: TableColumn<TRow>[];
-  data: TRow[];
+  columns: TableColumn[];
+  data: any[];
   expandable?: boolean;
   onRowExpand?: (rowId: string | number) => void;
-  renderExpanded?: (row: TRow) => React.ReactNode;
+  renderExpanded?: (row: any) => React.ReactNode;
   eyeInCity?: boolean;
   eyeColumnKey?: string;
   singleExpand?: boolean;
 }
 
-export const DataTable = <TRow extends Record<string, unknown>>({
+export const DataTable = ({
   title,
   columns,
   data,
@@ -42,7 +42,7 @@ export const DataTable = <TRow extends Record<string, unknown>>({
   eyeInCity = false,
   eyeColumnKey,
   singleExpand = false,
-}: DataTableProps<TRow>) => {
+}: DataTableProps) => {
   const [expandedRows, setExpandedRows] = useState<Set<string | number>>(new Set());
 
   const toggleRow = (rowId: string | number) => {
@@ -87,8 +87,7 @@ export const DataTable = <TRow extends Record<string, unknown>>({
           </TableHeader>
           <TableBody>
             {data.map((row, index) => {
-              const maybeId = (row as { id?: string | number }).id;
-              const rowId = maybeId ?? index;
+              const rowId = (row as any).id || index;
               const isExpanded = expandedRows.has(rowId);
               
               return (
@@ -123,7 +122,7 @@ export const DataTable = <TRow extends Record<string, unknown>>({
                     <TableCell key={column.key} className={cn("font-medium", column.cellClassName)}>
                       {eyeInCity && column.key === (eyeColumnKey || "city") ? (
                         <div className="flex items-center gap-2">
-                          <span>{(row as Record<string, unknown>)[column.key] as React.ReactNode || "-"}</span>
+                          <span>{row[column.key] || "-"}</span>
                           <Button
                             variant="ghost"
                             size="sm"
@@ -139,7 +138,7 @@ export const DataTable = <TRow extends Record<string, unknown>>({
                         // Gate selected columns until expanded when using eyeInCity
                         (eyeInCity && ["agency", "turnAroundTime", "fastestCity", "slowestCity", "avgTimeTaken"].includes(column.key) && !isExpanded)
                           ? <span>-</span>
-                          : (column.render ? column.render((row as Record<string, unknown>)[column.key], row) : <span>{(row as Record<string, unknown>)[column.key] as React.ReactNode || "-"}</span>)
+                          : (column.render ? column.render(row[column.key], row) : <span>{row[column.key] || "-"}</span>)
                       )}
                     </TableCell>
                   ))}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -49,8 +49,8 @@ const resolutionRatesSorted = [...resolutionRates].sort((a, b) => b.raised - a.r
 const Home = () => {
   return (
     <div className="space-y-6">
-      {/* Summary Cards - DSP style: 3 cards in a single row on desktop */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+      {/* Summary Cards - DSP style */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 gap-6">
         <IssueStatCard
           title="Actual Issues"
           target={totals.actualRaised}
@@ -60,6 +60,9 @@ const Home = () => {
           rightLabelText="Resolved"
           subtitle="(Average Resolution Rate)"
         />
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <MetricCard
           title="City with Highest Resolution Rate"
           value="Noida"
@@ -76,20 +79,25 @@ const Home = () => {
         />
       </div>
 
-      {/* Issues Status - Double Bar: Actual Raised vs Actual Resolved */}
+      {/* Issues Resolved Chart - Stacked with Line */}
       <IssuesChart
         title="Issue Status"
         data={resolvedChartData}
-        type="double"
+        type="stacked-line"
       />
 
       <IssuesChart
         title="Actual Resolution Rate by City"
-        data={resolutionRatesSorted}
+        data={resolutionRates}
         showTarget={false}
-        showLegend={true}
+        showLegend={false}
         valueSuffix="%"
-        orientation="horizontal"
+        getBarFill={(entry) => {
+          const v = Number((entry as any).raised) || 0;
+          if (v > 90) return "hsl(var(--success))";
+          if (v >= 80 && v <= 90) return "hsl(var(--warning))";
+          return "hsl(var(--danger))";
+        }}
       />
 
     </div>


### PR DESCRIPTION
Revert unintended DSP, citywise chart, and table style changes as requested by the user.

This PR reverts:
*   **DashboardHeader:** City buttons restored to original selected/unselected style, removing DSP-specific green variant.
*   **IssuesChart:** Removed DSP-specific threshold coloring, restored previous legend labels, and reverted chart type/thresholds to original.
*   **Home:** Restored layout to 2-column cards and original chart setup.
*   **DataTable:** Reverted prop/types and cell rendering that altered its look and behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-763463d7-997d-4390-9b5a-0ff7f2bcd12c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-763463d7-997d-4390-9b5a-0ff7f2bcd12c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

