### PR TITLE
Fix DSP home tab display issues

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -50,7 +50,7 @@ const Home = () => {
   return (
     <div className="space-y-6">
       {/* Summary Cards - DSP style */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 gap-6">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
         <IssueStatCard
           title="Actual Issues"
           target={totals.actualRaised}


### PR DESCRIPTION
Restore DSP Home summary cards to a single line layout on large screens by updating the grid configuration.

---
<a href="https://cursor.com/background-agent?bcId=bc-af8ad174-ddcd-47f9-8a7b-9bb430b1036f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-af8ad174-ddcd-47f9-8a7b-9bb430b1036f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

