### PR TITLE
Design DSP issue status cards for clarity

### DIFF
--- a/src/components/IssueStatCard.tsx
+++ b/src/components/IssueStatCard.tsx
@@ -27,8 +27,8 @@ export function IssueStatCard({ title, target, actual, variant, className, leftL
   const rightLabel = rightLabelText ?? (variant === "raised" ? "Resolved" : "Actual");
 
   return (
-    <Card className={cn("rounded-2xl p-5 md:p-6", bgByVariant[variant], className)}>
-      <div className="flex flex-col items-center gap-4">
+    <Card className={cn("rounded-2xl p-5 md:p-6 h-full", bgByVariant[variant], className)}>
+      <div className="flex flex-col h-full items-center gap-4">
         <h3 className={cn("text-xl md:text-2xl font-semibold text-center")}>{title}</h3>
 
         <div className="w-full grid grid-cols-3 items-center gap-2 md:gap-4">
@@ -54,10 +54,12 @@ export function IssueStatCard({ title, target, actual, variant, className, leftL
           </div>
         </div>
 
-        <div className="mt-2 text-center text-base md:text-lg font-semibold">{pct}%</div>
-        {subtitle && (
-          <div className="mt-1 text-center text-xs md:text-sm opacity-80">{subtitle}</div>
-        )}
+        <div className="mt-auto w-full flex flex-col items-center">
+          <div className="percent-emphasis">{pct}%</div>
+          {subtitle && (
+            <div className="mt-1 text-center text-xs md:text-sm opacity-80">{subtitle}</div>
+          )}
+        </div>
       </div>
     </Card>
   );

--- a/src/components/IssuesChart.tsx
+++ b/src/components/IssuesChart.tsx
@@ -175,7 +175,6 @@ export const IssuesChart = <TEntry extends ChartDataPoint = ChartDataPoint>({ ti
               <XAxis dataKey="name" stroke="hsl(var(--muted-foreground))" fontSize={12} fontWeight={500} interval={0} tick={xTickProps} tickMargin={isMobile ? 12 : 16} />
               <YAxis stroke="hsl(var(--muted-foreground))" fontSize={12} fontWeight={500} domain={[0, 'dataMax + 10']} tickCount={6} />
               <Tooltip content={<CustomTooltip />} />
-              <Legend wrapperStyle={{ fontSize: isMobile ? 12 : 14 }} verticalAlign="bottom" align="center" />
               <Bar dataKey="actualRaised" name="Actual Raised" fill="#555555" radius={[6, 6, 0, 0]} barSize={isMobile ? 20 : 28} isAnimationActive={!isMobile}>
                 <LabelList dataKey="actualRaised" position="top" content={<BarValueLabel />} />
               </Bar>
@@ -188,21 +187,7 @@ export const IssuesChart = <TEntry extends ChartDataPoint = ChartDataPoint>({ ti
               </Bar>
             </ComposedChart>
           </ResponsiveContainer>
-          {/* Color legend for Actual Resolved thresholds */}
-          <div className="mt-3 flex w-full items-center justify-center gap-4 text-xs sm:text-sm text-muted-foreground">
-            <div className="flex items-center gap-2">
-              <span className="h-2.5 w-2.5 rounded-sm" style={{ backgroundColor: '#4CAF50' }} />
-              <span>{'> 90% Resolved'}</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <span className="h-2.5 w-2.5 rounded-sm" style={{ backgroundColor: '#FFC107' }} />
-              <span>{'80% - 90% Resolved'}</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <span className="h-2.5 w-2.5 rounded-sm" style={{ backgroundColor: '#F44336' }} />
-              <span>{'< 80% Resolved'}</span>
-            </div>
-          </div>
+          
         </CardContent>
       </Card>
     );
@@ -236,7 +221,7 @@ export const IssuesChart = <TEntry extends ChartDataPoint = ChartDataPoint>({ ti
                 tickCount={6}
               />
               <Tooltip content={<CustomTooltip />} />
-              <Legend wrapperStyle={{ fontSize: isMobile ? 12 : 14 }} verticalAlign="bottom" align="center" />
+              {/* Legend removed as per DSP HOME requirement */}
               <Bar
                 dataKey="raised"
                 name="Issues Raised"

--- a/src/components/MetricCard.tsx
+++ b/src/components/MetricCard.tsx
@@ -39,44 +39,51 @@ export const MetricCard = ({
   return (
     <Card 
       className={cn(
-        "metric-card animate-card-enter interactive-hover",
+        "metric-card animate-card-enter interactive-hover h-full",
         variantClasses[variant],
         className
       )}
     >
-      <div className="flex items-start justify-between">
-        <div className="flex-1">
-          {headingOverride ? (
-            <h3 className={cn("text-lg font-semibold text-foreground", headingClassName)}>
-              {headingOverride}
-            </h3>
-          ) : (
-            <>
-              <h3 className="text-sm font-medium opacity-90 mb-3">{title}</h3>
-              <div className="flex items-baseline gap-3">
-                <span className="text-3xl font-bold tracking-tight">{value}</span>
-                {trend && (
-                  <span
-                    className={cn(
-                      "text-sm font-medium px-2 py-1 rounded-full transition-all duration-300",
-                      trend.isPositive
-                        ? "text-success-light bg-success/10"
-                        : "text-danger-light bg-danger/10"
-                    )}
-                  >
-                    {trend.isPositive ? "↗" : "↘"} {Math.abs(trend.value)}%
-                  </span>
-                )}
-              </div>
-              {subtitle && (
+      <div className="flex flex-col h-full">
+        <div className="flex items-start justify-between">
+          <div className="flex-1">
+            {headingOverride ? (
+              <h3 className={cn("text-lg font-semibold text-foreground", headingClassName)}>
+                {headingOverride}
+              </h3>
+            ) : (
+              <>
+                <h3 className="text-sm font-medium opacity-90 mb-3">{title}</h3>
+                <div className="flex items-baseline gap-3">
+                  <span className="text-3xl font-bold tracking-tight">{value}</span>
+                  {trend && (
+                    <span
+                      className={cn(
+                        "text-sm font-medium px-2 py-1 rounded-full transition-all duration-300",
+                        trend.isPositive
+                          ? "text-success-light bg-success/10"
+                          : "text-danger-light bg-danger/10"
+                      )}
+                    >
+                      {trend.isPositive ? "↗" : "↘"} {Math.abs(trend.value)}%
+                    </span>
+                  )}
+                </div>
+              {subtitle && !/%$/.test(subtitle) && (
                 <p className="text-sm opacity-80 mt-2 leading-relaxed">{subtitle}</p>
               )}
-            </>
+              </>
+            )}
+          </div>
+          {Icon && (
+            <div className="p-3 rounded-xl bg-black/10 animate-float">
+              <Icon className="h-7 w-7" />
+            </div>
           )}
         </div>
-        {Icon && (
-          <div className="p-3 rounded-xl bg-black/10 animate-float">
-            <Icon className="h-7 w-7" />
+        {subtitle && /%$/.test(subtitle) && (
+          <div className="mt-auto w-full flex items-center justify-start">
+            <div className="percent-emphasis inline-flex">{subtitle}</div>
           </div>
         )}
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -276,6 +276,20 @@
     transform: translateY(-2px);
     box-shadow: 0 8px 25px hsl(var(--primary) / 0.4);
   }
+
+  /* Elegant, Jony Ive-inspired percentage emphasis */
+  .percent-emphasis {
+    @apply font-extrabold tracking-tight;
+    font-size: clamp(1.75rem, 2.5vw, 2.25rem);
+    line-height: 1;
+    letter-spacing: -0.02em;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.5rem;
+    background: linear-gradient(180deg, hsl(var(--foreground) / 0.1), hsl(var(--foreground) / 0.06));
+    box-shadow: 0 6px 20px hsl(var(--foreground) / 0.15), inset 0 1px 0 hsl(0 0% 100% / 0.35);
+    color: currentColor;
+    backdrop-filter: blur(6px);
+  }
 }
 
 @keyframes pulse-glow {


### PR DESCRIPTION
Remove "Actual Raised" and "Actual Resolved" legends from the DSP Home issue status chart and align/highlight percentages in related cards.

The percentages in the `IssueStatCard` and `MetricCard` are now consistently styled and bottom-aligned within their cards, using a new `.percent-emphasis` utility class for a cleaner, more prominent display as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-d87fb44c-6155-4f9f-b93c-ffc62b05e5e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d87fb44c-6155-4f9f-b93c-ffc62b05e5e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

