### PR TITLE
Update DSP city page card colors

### DIFF
--- a/src/components/MetricCard.tsx
+++ b/src/components/MetricCard.tsx
@@ -7,7 +7,7 @@ interface MetricCardProps {
   value?: string | number;
   subtitle?: string;
   icon?: LucideIcon;
-  variant: "success" | "warning" | "danger" | "info" | "primary";
+  variant: "success" | "warning" | "danger" | "info" | "primary" | "neutral";
   trend?: {
     value: number;
     isPositive: boolean;
@@ -34,6 +34,7 @@ export const MetricCard = ({
     danger: "metric-card-danger",
     info: "metric-card-info",
     primary: "metric-card-primary",
+    neutral: "metric-card-neutral",
   };
 
   return (

--- a/src/index.css
+++ b/src/index.css
@@ -73,6 +73,7 @@
     --gradient-warning: linear-gradient(135deg, hsl(38 92% 50%) 0%, hsl(38 92% 43%) 50%, hsl(38 92% 57%) 100%);
     --gradient-danger: linear-gradient(135deg, hsl(0 72% 51%) 0%, hsl(0 72% 44%) 50%, hsl(0 72% 58%) 100%);
     --gradient-info: linear-gradient(135deg, hsl(201 96% 32%) 0%, hsl(201 96% 25%) 50%, hsl(201 96% 39%) 100%);
+    --gradient-neutral: linear-gradient(135deg, hsl(210 20% 95%) 0%, hsl(210 20% 90%) 50%, hsl(210 20% 97%) 100%);
     
     /* Glass morphism and depth gradients */
     --gradient-glass: linear-gradient(135deg, hsl(0 0% 100% / 0.1), hsl(0 0% 100% / 0.05));
@@ -198,6 +199,12 @@
     background: var(--gradient-primary);
     @apply text-primary-foreground shadow-lg;
     box-shadow: 0 8px 32px hsl(var(--primary) / 0.2);
+  }
+
+  .metric-card-neutral {
+    background: var(--gradient-neutral);
+    @apply text-foreground shadow-lg;
+    box-shadow: 0 8px 32px hsl(var(--foreground) / 0.08);
   }
 
   .nav-button {

--- a/src/pages/CityWise.tsx
+++ b/src/pages/CityWise.tsx
@@ -153,7 +153,7 @@ const CityWise = ({ activeModule, selectedCity }: CityWiseProps) => {
           value="8"
           subtitle="Issues raised Target Vs Actual : 92%"
           icon={Activity}
-          variant="warning"
+          variant="neutral"
         />
         <MetricCard
           title="In Active agency"
@@ -167,7 +167,7 @@ const CityWise = ({ activeModule, selectedCity }: CityWiseProps) => {
           value="Municipal Corp"
           subtitle="Avg. Issues Resolved Target Vs Actual : 96%"
           icon={TrendingUp}
-          variant="info"
+          variant="success"
         />
       </div>
 


### PR DESCRIPTION
Update DSP City-wise page card colors to match DSP Home, setting 'Top performer' to green and 'Onboarded agencies' to grey.

---
<a href="https://cursor.com/background-agent?bcId=bc-02188edb-e2aa-4381-9f5f-a039638d0bce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-02188edb-e2aa-4381-9f5f-a039638d0bce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

