### PR TITLE
Update DSP city view color scheme and tab visibility

### DIFF
--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -103,14 +103,17 @@ export const DashboardHeader = ({
         </div>
 
         {activeSection === "city-wise" && (
-          <div className="grid grid-cols-8 gap-1 py-1 border-t border-white/10">
+          <div className="grid grid-cols-8 gap-2 py-2 border-t border-white/10">
             {cities.map((city) => (
               <Button
                 key={city}
-                variant={selectedCity === city ? "default" : "outline"}
+                variant="ghost"
                 size="sm"
                 onClick={() => onCityChange(city)}
-                className="nav-button h-8 px-2 text-xs truncate"
+                className={cn(
+                  "city-tab truncate",
+                  selectedCity === city ? "city-tab-active" : "city-tab-inactive",
+                )}
               >
                 {city}
               </Button>

--- a/src/components/IssueStatCard.tsx
+++ b/src/components/IssueStatCard.tsx
@@ -16,8 +16,10 @@ interface IssueStatCardProps {
 }
 
 const bgByVariant: Record<Variant, string> = {
-  raised: "bg-yellow-300 text-black",
-  resolved: "bg-[#555555] text-white",
+  // Warm amber for "Actual Issues" left card per reference
+  raised: "bg-warning text-warning-foreground",
+  // Elegant dark slate gradient for resolved summary
+  resolved: "bg-[hsl(0_0%_26%)] text-white",
 };
 
 export function IssueStatCard({ title, target, actual, variant, className, leftLabelText, rightLabelText, subtitle }: IssueStatCardProps) {

--- a/src/index.css
+++ b/src/index.css
@@ -73,7 +73,8 @@
     --gradient-warning: linear-gradient(135deg, hsl(38 92% 50%) 0%, hsl(38 92% 43%) 50%, hsl(38 92% 57%) 100%);
     --gradient-danger: linear-gradient(135deg, hsl(0 72% 51%) 0%, hsl(0 72% 44%) 50%, hsl(0 72% 58%) 100%);
     --gradient-info: linear-gradient(135deg, hsl(201 96% 32%) 0%, hsl(201 96% 25%) 50%, hsl(201 96% 39%) 100%);
-    --gradient-neutral: linear-gradient(135deg, hsl(210 20% 95%) 0%, hsl(210 20% 90%) 50%, hsl(210 20% 97%) 100%);
+    /* Neutral card updated to elegant dark slate to match reference */
+    --gradient-neutral: linear-gradient(135deg, hsl(0 0% 34%) 0%, hsl(0 0% 28%) 50%, hsl(0 0% 22%) 100%);
     
     /* Glass morphism and depth gradients */
     --gradient-glass: linear-gradient(135deg, hsl(0 0% 100% / 0.1), hsl(0 0% 100% / 0.05));
@@ -203,8 +204,8 @@
 
   .metric-card-neutral {
     background: var(--gradient-neutral);
-    @apply text-foreground shadow-lg;
-    box-shadow: 0 8px 32px hsl(var(--foreground) / 0.08);
+    @apply text-white shadow-lg;
+    box-shadow: 0 8px 32px hsl(0 0% 0% / 0.25);
   }
 
   .nav-button {
@@ -226,6 +227,23 @@
     background: var(--gradient-header);
     @apply text-primary-foreground sticky top-0 z-50;
     box-shadow: 0 8px 32px hsl(var(--primary) / 0.15);
+  }
+
+  /* Jony Ive-inspired city tabs for header - high contrast and clarity */
+  .city-tab {
+    @apply inline-flex items-center justify-center h-8 px-3 rounded-lg text-xs font-medium transition-all duration-300 border;
+    backdrop-filter: blur(8px);
+  }
+
+  .city-tab-inactive {
+    @apply text-white/85 bg-white/10 border-white/20 hover:bg-white/15 hover:text-white;
+    box-shadow: 0 2px 10px hsl(0 0% 0% / 0.15) inset, 0 1px 0 hsl(0 0% 100% / 0.08);
+  }
+
+  .city-tab-active {
+    background: var(--gradient-primary);
+    @apply text-primary-foreground border-white/0 shadow-lg;
+    box-shadow: 0 8px 22px hsl(var(--primary) / 0.35), inset 0 1px 0 hsl(0 0% 100% / 0.35);
   }
 
   .chart-container {


### PR DESCRIPTION
Update DSP 'City Wise' card and tab color schemes to match design references and improve tab visibility.

The city tabs in the header were previously not visible due to styling issues. This PR introduces new styles to make them clearly distinguishable and highlights the active tab. Card colors were also adjusted to align with the provided visual examples.

---
<a href="https://cursor.com/background-agent?bcId=bc-de953385-2343-4194-85cd-f58768149b27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-de953385-2343-4194-85cd-f58768149b27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

