### PR TITLE
Update DSP city tabs display settings

### DIFF
--- a/src/pages/CityWise.tsx
+++ b/src/pages/CityWise.tsx
@@ -151,21 +151,18 @@ const CityWise = ({ activeModule, selectedCity }: CityWiseProps) => {
         <MetricCard
           title="Onboarded Agencies"
           value="8"
-          subtitle="Issues raised Target Vs Actual : 92%"
           icon={Activity}
           variant="neutral"
         />
         <MetricCard
-          title="In Active agency"
-          value="3"
-          subtitle="Issue Resolved Target Vs Actual : 67%"
+          title="Active agency"
+          value="5"
           icon={Clock}
           variant="danger"
         />
         <MetricCard
           title="Top Performer"
           value="Municipal Corp"
-          subtitle="Avg. Issues Resolved Target Vs Actual : 96%"
           icon={TrendingUp}
           variant="success"
         />


### PR DESCRIPTION
Update CityWise cards to change "In Active agency" to "Active agency", set its value to 5, and remove subtitles from all three cards.

---
<a href="https://cursor.com/background-agent?bcId=bc-cf896399-a9e2-408b-ab4d-8d7f7068e48e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cf896399-a9e2-408b-ab4d-8d7f7068e48e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

