### PR TITLE
Add design elements to numbers in DSP cards

### DIFF
--- a/src/components/MetricCard.tsx
+++ b/src/components/MetricCard.tsx
@@ -15,6 +15,7 @@ interface MetricCardProps {
   className?: string;
   headingOverride?: string;
   headingClassName?: string;
+  emphasizeValue?: boolean;
 }
 
 export const MetricCard = ({
@@ -27,6 +28,7 @@ export const MetricCard = ({
   className,
   headingOverride,
   headingClassName,
+  emphasizeValue,
 }: MetricCardProps) => {
   const variantClasses = {
     success: "metric-card-success",
@@ -56,7 +58,11 @@ export const MetricCard = ({
               <>
                 <h3 className="text-sm font-medium opacity-90 mb-3">{title}</h3>
                 <div className="flex items-baseline gap-3">
-                  <span className="text-3xl font-bold tracking-tight">{value}</span>
+                  {emphasizeValue ? (
+                    <span className="value-badge text-xl">{value}</span>
+                  ) : (
+                    <span className="text-3xl font-bold tracking-tight">{value}</span>
+                  )}
                   {trend && (
                     <span
                       className={cn(

--- a/src/index.css
+++ b/src/index.css
@@ -315,6 +315,16 @@
     color: currentColor;
     backdrop-filter: blur(6px);
   }
+
+  /* Rounded green badge around numbers (as in reference image) */
+  .value-badge {
+    @apply inline-flex items-center justify-center font-bold text-white;
+    padding: 0.125rem 0.5rem; /* 2px 8px */
+    border-radius: 0.5rem; /* 8px */
+    background: linear-gradient(180deg, hsl(var(--success) / 0.95), hsl(var(--success) / 0.9));
+    box-shadow: 0 6px 18px hsl(var(--success) / 0.35), inset 0 1px 0 hsl(0 0% 100% / 0.35);
+    letter-spacing: -0.01em;
+  }
 }
 
 @keyframes pulse-glow {

--- a/src/pages/CityWise.tsx
+++ b/src/pages/CityWise.tsx
@@ -154,11 +154,13 @@ const CityWise = ({ activeModule, selectedCity }: CityWiseProps) => {
             title="Onboarded Agencies"
             value="8"
             variant="neutral"
+            emphasizeValue
           />
           <MetricCard
             title="In Active agency"
             value="3"
             variant="danger"
+            emphasizeValue
           />
           <MetricCard
             title="Top Performer"


### PR DESCRIPTION
Add rounded green badge style to numbers in DSP city-wise cards to match design specifications.

---
<a href="https://cursor.com/background-agent?bcId=bc-498a127f-113e-498a-aa02-b06bb3f9baf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-498a127f-113e-498a-aa02-b06bb3f9baf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

