### PR TITLE
Fix missing bar names display

### DIFF
--- a/src/components/IssuesChart.tsx
+++ b/src/components/IssuesChart.tsx
@@ -347,8 +347,8 @@ export const IssuesChart = <TEntry extends ChartDataPoint = ChartDataPoint>({ ti
                   fontWeight={600}
                   interval={0}
                   tick={<WrappedCategoryTick />}
-                  tickMargin={8}
-                  width={isMobile ? 144 : 220}
+                  tickMargin={12}
+                  width={isMobile ? 200 : 320}
                 />
               </>
             ) : (


### PR DESCRIPTION
Increase Y-axis width and tick margin to prevent bar names from being clipped.

---
<a href="https://cursor.com/background-agent?bcId=bc-b37c6f50-69bf-4af2-a9f5-530887972d24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b37c6f50-69bf-4af2-a9f5-530887972d24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

