### PR TITLE
Make chart vertical for bar visibility

### DIFF
--- a/src/components/IssuesChart.tsx
+++ b/src/components/IssuesChart.tsx
@@ -40,7 +40,7 @@ interface IssuesChartProps<TEntry extends ChartDataPoint = ChartDataPoint> {
 export const IssuesChart = <TEntry extends ChartDataPoint = ChartDataPoint>({ title, data, type = "bar", showTarget = true, showActual = true, valueSuffix, showLegend = true, showPercentOfTarget = false, getBarFill, orientation = "vertical" }: IssuesChartProps<TEntry>) => {
   const isMobile = useIsMobile();
   const xTickProps = { angle: 0 as const, textAnchor: "middle" as const };
-  const isHorizontal = orientation === "horizontal" || (!!valueSuffix && valueSuffix.includes("%") && showActual && !showTarget && type === "bar");
+  const isHorizontal = orientation === "horizontal";
   const isPercentOnly = !!valueSuffix && valueSuffix.includes('%') && showActual && !showTarget && type === 'bar';
 
   // Wrapped tick renderer for long category names on horizontal (category Y-axis)


### PR DESCRIPTION
Force bar chart to render vertically by default to make category names visible.

---
<a href="https://cursor.com/background-agent?bcId=bc-682de47b-046d-4adb-925b-502fffad459a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-682de47b-046d-4adb-925b-502fffad459a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

