### PR TITLE
Make issue type chart vertical and readable

### DIFF
--- a/src/components/IssuesChart.tsx
+++ b/src/components/IssuesChart.tsx
@@ -39,8 +39,17 @@ interface IssuesChartProps<TEntry extends ChartDataPoint = ChartDataPoint> {
 
 export const IssuesChart = <TEntry extends ChartDataPoint = ChartDataPoint>({ title, data, type = "bar", showTarget = true, showActual = true, valueSuffix, showLegend = true, showPercentOfTarget = false, getBarFill, orientation = "vertical" }: IssuesChartProps<TEntry>) => {
   const isMobile = useIsMobile();
-  const xTickProps = { angle: 0 as const, textAnchor: "middle" as const };
   const isHorizontal = orientation === "horizontal";
+  const maxNameLength = Array.isArray(data) && data.length > 0
+    ? Math.max(...data.map((d) => (d?.name ? String(d.name).length : 0)))
+    : 0;
+  const requiresRotation = !isHorizontal && (
+    (isMobile && (maxNameLength > 10 || data.length > 6)) ||
+    (!isMobile && (maxNameLength > 16 || data.length > 8))
+  );
+  const xTickProps = requiresRotation
+    ? ({ angle: -35 as const, textAnchor: "end" as const })
+    : ({ angle: 0 as const, textAnchor: "middle" as const });
   const isPercentOnly = !!valueSuffix && valueSuffix.includes('%') && showActual && !showTarget && type === 'bar';
 
   // Wrapped tick renderer for long category names on horizontal (category Y-axis)
@@ -212,7 +221,7 @@ export const IssuesChart = <TEntry extends ChartDataPoint = ChartDataPoint>({ ti
         </CardHeader>
         <CardContent>
           <ResponsiveContainer width="100%" height={isMobile ? 360 : 460}>
-            <ComposedChart data={data} margin={{ top: (isMobile ? 56 : 40), right: (isMobile ? 16 : 30), left: (isMobile ? 12 : 20), bottom: (isMobile ? 64 : 56) }} barCategoryGap={isMobile ? '35%' : '20%'} barGap={isMobile ? 2 : 4}>
+            <ComposedChart data={data} margin={{ top: (isMobile ? 56 : 40), right: (isMobile ? 16 : 30), left: (isMobile ? 12 : 20), bottom: (requiresRotation ? (isMobile ? 88 : 80) : (isMobile ? 64 : 56)) }} barCategoryGap={isMobile ? '35%' : '20%'} barGap={isMobile ? 2 : 4}>
               <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" opacity={0.5} />
               <XAxis dataKey="name" stroke="hsl(var(--muted-foreground))" fontSize={12} fontWeight={500} interval={0} tick={xTickProps} tickMargin={isMobile ? 12 : 16} />
               <YAxis stroke="hsl(var(--muted-foreground))" fontSize={12} fontWeight={500} domain={[0, 'dataMax + 10']} tickCount={6} />
@@ -360,7 +369,7 @@ export const IssuesChart = <TEntry extends ChartDataPoint = ChartDataPoint>({ ti
                   fontWeight={500}
                   interval={0}
                   tick={xTickProps}
-                  tickMargin={isMobile ? 12 : 16}
+                  tickMargin={requiresRotation ? 6 : (isMobile ? 12 : 16)}
                 />
                 <YAxis
                     stroke="hsl(var(--muted-foreground))"

--- a/src/pages/CityWise.tsx
+++ b/src/pages/CityWise.tsx
@@ -177,7 +177,7 @@ const CityWise = ({ activeModule, selectedCity }: CityWiseProps) => {
           type="bar"
           showTarget={false}
           showActual={true}
-          orientation="horizontal"
+          orientation="vertical"
         />
 
         <IssuesChart


### PR DESCRIPTION
Change the 'Issues Raised by Issue Type' chart to vertical and add automatic X-axis label rotation for improved visibility of bar names.

---
<a href="https://cursor.com/background-agent?bcId=bc-22f1cbf8-80ce-40aa-8e69-8bb10e3c7e53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-22f1cbf8-80ce-40aa-8e69-8bb10e3c7e53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

