### PR TITLE
Revert dsp home chart change

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -81,7 +81,6 @@ const Home = () => {
         title="Issue Status"
         data={resolvedChartData}
         type="double"
-        showDSPResolutionLegend={true}
       />
 
       <IssuesChart
@@ -92,11 +91,10 @@ const Home = () => {
         valueSuffix="%"
         getBarFill={(entry) => {
           const v = Number(entry.raised ?? 0) || 0;
-          if (v >= 90) return '#4CAF50';
-          if (v >= 50) return '#FFC107';
-          return '#F44336';
+          if (v > 90) return "hsl(var(--success))";
+          if (v >= 80 && v <= 90) return "hsl(var(--warning))";
+          return "hsl(var(--danger))";
         }}
-        showDSPResolutionLegend={true}
       />
 
     </div>


### PR DESCRIPTION
Revert DSP Home tab chart to its previous version.

The user requested to revert the chart in the DSP Home tab back to its last version.

---
<a href="https://cursor.com/background-agent?bcId=bc-25994b4b-6d62-4f3b-b227-d3a43e5c29e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-25994b4b-6d62-4f3b-b227-d3a43e5c29e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

