### PR TITLE
Create combined chart in DSP city tab

### DIFF
--- a/src/pages/CityWise.tsx
+++ b/src/pages/CityWise.tsx
@@ -170,35 +170,11 @@ const CityWise = ({ activeModule, selectedCity }: CityWiseProps) => {
           />
         </div>
 
-        {/* Issues Charts for Selected City (bar charts with all issue types visible) */}
+        {/* Combined chart: Issues Raised (dark) vs Resolved (color-coded with %) */}
         <IssuesChart
-          title={`${selectedCity}: Issues Raised by Issue Type`}
-          data={chartData.map(d => ({ name: d.name, raised: d.raised, actualRaised: d.raised, actualResolved: d.resolved }))}
-          type="bar"
-          showTarget={false}
-          showActual={true}
-          orientation="vertical"
-          showDSPResolutionLegend={true}
-          getBarFill={() => '#4A4A4A'}
-        />
-
-        <IssuesChart
-          title={`${selectedCity}: Issues Resolved by Issue Type`}
-          data={chartData.map(d => ({ name: d.name, raised: d.resolved, actualRaised: d.raised }))}
-          type="bar"
-          showTarget={false}
-          showActual={true}
-          orientation="horizontal"
-          showDSPResolutionLegend={true}
-          getBarFill={(entry) => {
-            const e: any = entry as any;
-            const den = Number(e?.actualRaised ?? 0) || 0;
-            const num = Number(e?.raised ?? 0) || 0;
-            const pct = den > 0 ? Math.round((num / den) * 100) : 0;
-            if (pct >= 90) return '#4CAF50';
-            if (pct >= 50) return '#FFC107';
-            return '#F44336';
-          }}
+          title={`${selectedCity}: Issues Raised vs Resolved by Issue Type`}
+          data={chartData.map(d => ({ name: d.name, actualRaised: d.raised, actualResolved: d.resolved }))}
+          type="double"
         />
 
         {/* Agency Performance Table */}


### PR DESCRIPTION
Combine 'Issues Raised' and 'Issues Resolved' charts into a single combined chart on the DSP City Wise tab.

This change implements the user's request to display raised and resolved issues together in one chart, utilizing the existing `IssuesChart` component's `double` type which provides the desired layout, percentage labels, and color-coding for resolved issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-7f1b1a45-0f8c-4a0d-ad40-53c3e0ebb70e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7f1b1a45-0f8c-4a0d-ad40-53c3e0ebb70e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

