### PR TITLE
Freeze table header on agency performance details

### DIFF
--- a/src/pages/CityWise.tsx
+++ b/src/pages/CityWise.tsx
@@ -189,17 +189,14 @@ const CityWise = ({ activeModule, selectedCity }: CityWiseProps) => {
 
         {/* Agency Performance Table */}
         {(() => {
-          const isDelhi = selectedCity === "Delhi";
           const stickyHeaderClasses = "sticky top-0 z-10 bg-muted/60 backdrop-blur supports-[backdrop-filter]:bg-muted/40";
-          const dspColumns = isDelhi
-            ? agencyColumns.map((col) => ({
-                ...col,
-                headerClassName: `${col.headerClassName ? col.headerClassName + " " : ""}${stickyHeaderClasses}`,
-              }))
-            : agencyColumns;
+          const dspColumns = agencyColumns.map((col) => ({
+            ...col,
+            headerClassName: `${col.headerClassName ? col.headerClassName + " " : ""}${stickyHeaderClasses}`,
+          }));
 
           return (
-            <div className={isDelhi ? "max-h-96 overflow-y-auto" : ""}>
+            <div className="max-h-96 overflow-y-auto">
               <DataTable
                 title="Agency Performance Details"
                 columns={dspColumns}


### PR DESCRIPTION
Apply sticky headers and vertical scrolling to the 'Agency Performance Details' table in the DSP City wise page, now universally, to ensure the header remains visible during scrolling.

---
<a href="https://cursor.com/background-agent?bcId=bc-3a792f82-ba58-4b82-aa78-8be0ab6af566"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3a792f82-ba58-4b82-aa78-8be0ab6af566"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

