### PR TITLE
Update active agencies count in DSP card

### DIFF
--- a/src/pages/CityWise.tsx
+++ b/src/pages/CityWise.tsx
@@ -168,7 +168,7 @@ const CityWise = ({ activeModule, selectedCity }: CityWiseProps) => {
           />
           <MetricCard
             title="Active agencies"
-            value="3"
+          value="9"
             variant="danger"
             helperText="Agency resolving atleast one issue in the month"
             emphasizeValue


### PR DESCRIPTION
Update the 'Active agencies' metric value from 3 to 9 on the DSP City Wise page as per user request.

---
<a href="https://cursor.com/background-agent?bcId=bc-f84c6218-a191-4a36-8a34-9be33296038b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f84c6218-a191-4a36-8a34-9be33296038b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

